### PR TITLE
fix: show click icon when hovering options menu

### DIFF
--- a/src/lib/components/button/options-button.svelte
+++ b/src/lib/components/button/options-button.svelte
@@ -5,7 +5,11 @@
 	$: active = false;
 </script>
 
-<div class="flex items-center" on:click={() => (active = !active)} aria-hidden="true">
+<div
+	class="flex items-center cursor-pointer"
+	on:click={() => (active = !active)}
+	aria-hidden="true"
+>
 	<div>
 		<svg xmlns="http://www.w3.org/2000/svg" width="28" height="28" viewBox="0 0 24 24">
 			<path


### PR DESCRIPTION
![image](https://github.com/paginas-secretas/paginas-secretas/assets/104737871/45ae8a1b-82f0-4885-9817-e8cc81d883cc)
