### PR TITLE
enhancement: alert message wrap text  while keeping the existent break lines

### DIFF
--- a/src/lib/components/alert/index.svelte
+++ b/src/lib/components/alert/index.svelte
@@ -30,13 +30,12 @@
 			</div>
 
 			{#if isURL}
-				<div class="text-wrap break-words">
+				<div class="break-all">
 					<a class="link link-primary" href={value.message}>{value.message}</a>
 				</div>
 			{:else}
-				<div class="text-wrap break-words">{value.message}</div>
+				<div class="break-words whitespace-pre-wrap">{value.message}</div>
 			{/if}
-
 			<div class="pt-5">
 				<div class="justify-between">
 					<button type="submit" class="btn btn-primary w-full" on:click={value.action[1]}


### PR DESCRIPTION
**Before:**

![image](https://github.com/paginas-secretas/paginas-secretas/assets/104737871/d487001e-82c1-4610-a656-e650453331e8)


![image](https://github.com/paginas-secretas/paginas-secretas/assets/104737871/0a339ca4-03dd-4ac9-9953-d2a2d9486129)



**After:**

![image](https://github.com/paginas-secretas/paginas-secretas/assets/104737871/fbb66477-9524-4623-8dbf-342765bed63e)

![image](https://github.com/paginas-secretas/paginas-secretas/assets/104737871/7cfdde03-dc7f-42ed-b936-2edc51489160)



### Explanation of solution:

> To add line breaks mid-word but without trying to preserve whole words use break-all

- `break-all`: https://tw-elements.com/docs/standard/extended/text-wrap/


> Sequences of white space are preserved. Lines are broken at newline characters, at `<br>`

- `break-words whitespace-pre-wrap`: https://stackoverflow.com/a/644008