### PR TITLE
enhancement: save button should only appear when the contacts list changes

### DIFF
--- a/src/lib/components/contacts/index.svelte
+++ b/src/lib/components/contacts/index.svelte
@@ -19,10 +19,8 @@
 	const generateKeyPairTranslations = $LL.alert.generatePublicKey;
 	const sharedContactsListTranslations = $LL.alert.sharedContactsList;
 
-	let previousContactsListSize = $contactsListStore.value.value.length;
-
 	$: contactSelected = contactsList.at(-1);
-	$: unsavedChanges = previousContactsListSize != $contactsListStore.value.value.length;
+	$: unsavedChanges = !$contactsListStore.value.isSaved;
 	$: showShareModalForm = false;
 	$: showNewContactModalForm = false;
 	$: showSharedContactsListAlert = $shareContactsStore.success;
@@ -121,12 +119,7 @@
 			}}
 		/>
 		{#if unsavedChanges}
-			<SaveContactsListButton
-				onClick={() => {
-					contactsListStore.triggerStoreContactsList();
-					previousContactsListSize = $contactsListStore.value.value.length;
-				}}
-			/>
+			<SaveContactsListButton onClick={() => contactsListStore.triggerStoreContactsList()} />
 		{/if}
 	</div>
 </div>

--- a/src/lib/stores/contacts-list.ts
+++ b/src/lib/stores/contacts-list.ts
@@ -27,6 +27,7 @@ type ContactsListState = {
 	keyPair: AsymmetricKeyPair;
 	symmetricKey: SymmetricKey;
 	value: ContactsList;
+	isSaved: boolean;
 };
 
 function createContactsListStore() {
@@ -53,7 +54,8 @@ function createContactsListStore() {
 			setSuccess(store, {
 				keyPair: keyPair,
 				symmetricKey: symmetricKey,
-				value: contactsList
+				value: contactsList,
+				isSaved: false
 			}),
 		triggerStoreContactsList: () =>
 			triggerStoreContactsList(
@@ -77,7 +79,8 @@ async function triggerCreateContactsList(
 	setSuccess(store, {
 		keyPair: keyPair,
 		symmetricKey: symmetricKey,
-		value: []
+		value: [],
+		isSaved: true
 	});
 }
 
@@ -97,6 +100,7 @@ async function triggerAddContact(store: Store<ContactsListState>, submission: Fo
 	};
 
 	store.update((s) => {
+		s.value.isSaved = false;
 		s.value.value.push(contact);
 		return from(s.value, State.success);
 	});
@@ -147,6 +151,11 @@ async function triggerStoreContactsList(
 	};
 
 	const partialEncryptedContactsList = await manager.add(btoa(JSON.stringify(encryptedContacts)));
+
+	store.update((s) => {
+		s.value.isSaved = true;
+		return from(s.value, s.state);
+	});
 
 	storage.store(
 		`${partialEncryptedContactsList.ref}/${partialEncryptedContactsList.hash}`,


### PR DESCRIPTION
**After**

https://github.com/paginas-secretas/paginas-secretas/assets/104737871/ad823751-57d7-4469-a6ab-3a62c4dd61ec


### Explanation of solution:

The validation is based on the attribute `isSaved` in the contacts list store.
When the contacts list store is created, `isSaved` is initiated with `true` value. Whenever the list is changed (`triggerAddContact`), this is also changed to `false` (`s.value.isSaved = false;`). When the list is stored (`triggerStoreContactsList`), which happens when the save button is clicked, the value is changed back to `true` (`s.value.isSaved = true;`). 
So the save button will only be shown when `isSaved` is `true` (`$: unsavedChanges = !$contactsListStore.value.isSaved;`)